### PR TITLE
Show the loaded ACE slot as the number printed on the box (was off by one)

### DIFF
--- a/custom_components/anycubic_cloud/coordinator.py
+++ b/custom_components/anycubic_cloud/coordinator.py
@@ -477,7 +477,20 @@ class AnycubicCloudDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "print_time_total_hrs": printer.total_print_time_hrs,
             "print_count_total": printer.print_count,
             "job_filament_used": printer.latest_project_supplies_usage,
-            "ace_loaded_slot": printer.primary_multi_color_box_loaded_slot,
+            # The printer reports the feeding ACE slot 0-based (-1 = nothing
+            # loaded), but the sensor is named after the slot numbers printed on
+            # the box itself, which start at 1 -- so "Fach 1" in use showed up as
+            # "0" here. Report the human-facing slot number instead, and nothing
+            # (not -1) when the box is idle; that also matches what the docs
+            # below already promised ("reads unavailable when nothing is loaded").
+            # _as_slot_index() does double duty here: it keeps non-numeric or
+            # negative wire values from being treated as slots at all, which is
+            # what let a bare MagicMock stand in for the printer in tests.
+            "ace_loaded_slot": (
+                slot_wire + 1
+                if (slot_wire := _as_slot_index(printer.primary_multi_color_box_loaded_slot)) is not None
+                else None
+            ),
             "aux_fan_speed_pct": printer.aux_fan_speed_pct,
             # The external filament holder, for printers fed from a single
             # external spool rather than (or alongside) the ACE. Already in the

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -517,3 +517,42 @@ class TestRevokedStoredTokensDoNotBlockReauth:
         await setup_entry(hass, mock_entry)
 
         assert mock_entry.state is ConfigEntryState.SETUP_ERROR, mock_entry.state
+
+
+class TestAceLoadedSlotNumbering:
+    """The loaded-slot sensor carries the number printed on the ACE itself.
+
+    The cloud payload counts slots from 0 (-1 when nothing is fed), while the
+    box labels its slots from 1 -- so a print running from slot 1 used to show
+    up as "0", and an idle box as "-1" rather than unavailable.
+    """
+
+    @pytest.mark.parametrize(
+        ("wire_value", "expected"),
+        [
+            (0, 1),  # first slot feeding: wire says 0, the box says 1
+            (2, 3),  # last slot feeding
+            (-1, None),  # nothing loaded reads unavailable, not "-1"
+            (None, None),  # no answer at all stays unknown
+        ],
+    )
+    async def test_the_sensor_shows_the_human_facing_number(self, hass, mock_entry, mock_api, wire_value, expected) -> None:
+        from unittest.mock import PropertyMock
+
+        from helpers import setup_entry
+
+        await setup_entry(hass, mock_entry)
+        coordinator = mock_entry.runtime_data
+        _api, printer = mock_api
+
+        with (
+            patch.object(
+                type(printer),
+                "primary_multi_color_box_loaded_slot",
+                PropertyMock(return_value=wire_value),
+            ),
+            patch.object(coordinator, "_poll_printer_capabilities", AsyncMock()),
+        ):
+            states = coordinator._build_printer_dict(printer)["states"]
+
+        assert states["ace_loaded_slot"] == expected


### PR DESCRIPTION
## Summary

`sensor.*_ace_loaded_slot` showed the raw wire value of `primary_multi_color_box_loaded_slot`, which counts ACE slots **0-based** (`-1` when nothing is fed). The sensor name promises the number printed on the machine's slot labels, which start at 1 -- so users saw an off-by-one mismatch between what the ACE screen says and what the sensor reports:

| Printer state | ACE shows | Sensor showed | Sensor shows now |
|---|---|---|---|
| Printing from slot 1 | Fach/Slot 1 | `0` ❌ | `1` ✅ |
| Printing from slot 3 | Fach/Slot 3 | `2` ❌ | `3` ✅ |
| Nothing feeding | -- | `-1` ❌ | `unavailable` ✅ |

The idle case now also matches what the README's automation recipes already promised ("reads `unavailable` when nothing is loaded").

Internal consumers are unaffected: job charging, feed tracking and run-out math read the raw printer value through `_as_slot_index()`, which was already correct. This only changes what the entity displays.

## Changes

- `coordinator.py`: report `wire_value + 1` for valid slots, `None` otherwise. Reuses `_as_slot_index()` so non-numeric or negative values keep being rejected the same way everywhere else.
- `tests/test_coordinator.py`: new `TestAceLoadedSlotNumbering` covering `0→1`, `2→3`, `-1→None` and `None→None`.

## Transparency: AI-assisted analysis and implementation 🤖

For full disclosure, per the maintainer's preference for transparent contributions:

- **Found by a human**: @mkslzk noticed his printer pulling from slot 1 while the sensor said `0` on a real Kobra S1 + ACE Pro, and correctly suspected an array-index convention issue.
- **Analyzed with AI**: the code path (`coordinator.py` → `_as_slot_index()` → consumers), duplicate checks against open/closed PRs and issues, and the consumer audit were worked out with an AI agent ([Charlie](https://github.com/mkslzk), Hermes Agent).
- **Implemented with AI**: the patch and test were drafted by the same agent, then verified end-to-end by the human:
  - Live-verified against **two** Kobra S1 units with ACE Pro while both were mid-print (states matched the physically used slots: 1 → `1`, 3 → `3`).
  - Full local CI parity before opening: `ruff check` clean, `ruff format --check tests` clean, `mypy` strict clean, **852 passed / 2 skipped** including the new parametrized cases.

## Test plan

- [x] New parametrized tests pass locally (`4 passed`)
- [x] Full suite green locally: `852 passed, 2 skipped`
- [x] `ruff check custom_components tests` clean
- [x] `ruff format --check tests` clean
- [x] `mypy custom_components/anycubic_cloud` strict clean
- [x] Live-verified on 2× Kobra S1 + ACE Pro during active prints