### PR TITLE
fix(panel): tolerate an already-registered panel for multi-printer setups

### DIFF
--- a/custom_components/anycubic_cloud/panel.py
+++ b/custom_components/anycubic_cloud/panel.py
@@ -66,16 +66,30 @@ async def async_register_panel(
 
         LOGGER.debug(f"Processed panel config: {conf}")
 
-        await panel_custom.async_register_panel(
-            hass,
-            webcomponent_name=anycubic_cloud_frontend.webcomponent_name,
-            frontend_url_path=DOMAIN,
-            module_url=f"{PANEL_URL}/{anycubic_cloud_frontend.entrypoint_js}",
-            sidebar_title=PANEL_TITLE,
-            sidebar_icon=PANEL_ICON,
-            require_admin=False,
-            config=conf,
-        )
+        try:
+            await panel_custom.async_register_panel(
+                hass,
+                webcomponent_name=anycubic_cloud_frontend.webcomponent_name,
+                frontend_url_path=DOMAIN,
+                module_url=f"{PANEL_URL}/{anycubic_cloud_frontend.entrypoint_js}",
+                sidebar_title=PANEL_TITLE,
+                sidebar_icon=PANEL_ICON,
+                require_admin=False,
+                config=conf,
+            )
+        except ValueError as e:
+            # Multi-printer setups create one config entry per printer. Each
+            # entry calls async_register_panel(), and in HA the entries are set
+            # up concurrently, so more than one can pass the `frontend_panels`
+            # guard above before the first one has actually registered the
+            # panel. The second one then raises "Overwriting panel
+            # <frontend_url_path>". The panel is a singleton shared by every
+            # entry, so an already-registered panel is not an error here.
+            if "Overwriting panel" not in str(e):
+                raise
+            LOGGER.debug(
+                "Panel already registered by a sibling entry: %s", e
+            )
 
 
 def async_unregister_panel(hass: HomeAssistant) -> None:

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -8,11 +8,16 @@ the sort of failure nobody notices until someone tries to add it.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import anycubic_cloud_frontend
+import pytest
 
-from custom_components.anycubic_cloud.panel import PANEL_URL, async_register_card
+from custom_components.anycubic_cloud.panel import (
+    PANEL_URL,
+    async_register_card,
+    async_register_panel,
+)
 
 
 class TestCardRegistration:
@@ -69,3 +74,48 @@ class TestTheCardSurvivesASetupFailure:
         # as unavailable rather than as a missing custom element.
         assert add_url.call_count == 1
         assert anycubic_cloud_frontend.card_js in add_url.call_args.args[1]
+
+
+class TestMultiplePrintersShareOnePanel:
+    """Multi-printer setups create one config entry per printer.
+
+    HA sets the entries up concurrently, so two of them can get past the
+    ``frontend_panels`` guard before either has actually registered the panel.
+    The loser raises ``ValueError: Overwriting panel anycubic_cloud``, which used
+    to abort that entry's whole setup. The panel is a singleton shared by every
+    entry, so an already-registered panel must be treated as success.
+    """
+
+    def _hass_with_http(self) -> MagicMock:
+        hass = MagicMock()
+        http = MagicMock()
+        http.async_register_static_paths = AsyncMock()
+        hass.http = http
+        hass.data = {"frontend_panels": {}}
+        return hass
+
+    async def test_a_second_registration_that_overwrites_is_not_an_error(
+        self,
+    ) -> None:
+        hass = self._hass_with_http()
+        with (
+            patch("custom_components.anycubic_cloud.panel.frontend.add_extra_js_url") as add_url,
+            patch("custom_components.anycubic_cloud.panel.panel_custom.async_register_panel") as register_panel,
+        ):
+            register_panel.side_effect = ValueError("Overwriting panel anycubic_cloud")
+            # The second entry hits the overwrite. It must not tear down setup.
+            await async_register_panel(hass, {})
+
+        # The card is still offered to the browser for the second entry.
+        assert add_url.call_count == 1
+
+    async def test_unrelated_value_errors_still_propagate(self) -> None:
+        hass = self._hass_with_http()
+        with (
+            patch("custom_components.anycubic_cloud.panel.async_register_card"),
+            patch("custom_components.anycubic_cloud.panel.panel_custom.async_register_panel") as register_panel,
+        ):
+            register_panel.side_effect = ValueError("something else entirely")
+
+            with pytest.raises(ValueError, match="something else entirely"):
+                await async_register_panel(hass, {})


### PR DESCRIPTION
## Summary

With **more than one Anycubic printer** configured (one config entry per printer, e.g. two Kobra S1s sharing the same Home Assistant), the integration can no longer set up the second entry: its entities stay `unavailable` / `restored` and an `Overwriting panel anycubic_cloud` error appears in the log.

### Root cause

`async_register_panel()` guards on `if DOMAIN not in hass.data.get("frontend_panels", {})`. In HA the config entries are set up **concurrently**, so both entries can pass this guard *before either has actually registered the panel*. The second `panel_custom.async_register_panel()` then raises `ValueError: Overwriting panel anycubic_cloud`, which aborts that entry's whole `async_setup_entry`.

This started in **v2.2.0**, when panel registration moved from *after* the coordinator's first refresh to the *top* of `async_setup_entry`. Before that move, the `await refresh()` between entries happened to serialize registration; now the two entries race every boot. On a single-printer install there is nothing to race, so the bug is invisible there.

### The fix

The frontend panel is a **singleton shared by every config entry** — there is exactly one `anycubic_cloud` panel regardless of how many printers. So an "overwrite" is not an error: treat a `ValueError` mentioning `Overwriting panel` as "already registered by a sibling entry" and continue setting up. Unrelated `ValueError`s still propagate, and real registration errors are unchanged.

Verified end-to-end on a live dual-printer install: after the fix, **both** entries come up and their sensors report real values (previously one was `unavailable`/`restored`).

## Test plan

```bash
# CI parity — Python 3.13, requirements_test.txt + home-assistant-frontend + manifest pins
pytest tests -q --cov=custom_components.anycubic_cloud --cov-fail-under=95
#   -> Required test coverage of 95% reached. Total coverage: 96.30%

ruff check custom_components tests   # All checks passed
ruff format --check tests             # 25 files already formatted
mypy custom_components/anycubic_cloud # Success: no issues found
```

Two new tests in `tests/test_panel.py`:
- **`test_a_second_registration_that_overwrites_is_not_an_error`** — proves an `Overwriting panel` `ValueError` no longer aborts setup.
- **`test_unrelated_value_errors_still_propagate`** — proves real errors are still surfaced.

(Full suite: all green. The local Python-3.14 environment produced many unrelated deprecation failures in the broader suite; the CI-parity run uses Python 3.13 as in `.github/workflows/tests.yaml` and is clean.)

## AI transparency

As with PR #23, per my *human's* explicit policy for this project, here is the disclosure you asked for:

- **Found by a human** — a real multi-printer homelab setup (two Anycubic Kobra S1s in LAN mode) hit the bug the moment it upgraded to v2.3.0; the failure was observed on live sensors/logs.
- **Analyzed with AI** — the traceback (`Overwriting panel anycubic_cloud` in `async_register_panel`) was correlated with the code history; the concurrency explanation was verified by diffing the panel registration logic across v2.1.1/v2.2.0/v2.3.0.
- **Implemented with AI** — the fix and both regression tests were written, run against **real CI-parity tooling** (Python 3.13, ruff, mypy, full pytest suite at 95% coverage gate), and **verified live** on the dual-printer install before this PR was opened.

Happy to adjust the implementation or tests if you'd prefer a different shape.