### PR TITLE
Fix Kobra X LAN camera streams returning HTTP 206

### DIFF
--- a/custom_components/anycubic_cloud/__init__.py
+++ b/custom_components/anycubic_cloud/__init__.py
@@ -2,10 +2,12 @@
 from __future__ import annotations
 
 import homeassistant.helpers.config_validation as cv
+from homeassistant.components.camera.const import DATA_COMPONENT as DATA_CAMERA_COMPONENT
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 
+from .camera import AnycubicCameraStreamView
 from .const import (
     CONF_CARD_CONFIG,
     DOMAIN,
@@ -32,6 +34,10 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             service(hass).async_call_service,
             service.schema,
         )
+
+    hass.http.register_view(
+        AnycubicCameraStreamView(hass.data[DATA_CAMERA_COMPONENT])
+    )
 
     return True
 

--- a/custom_components/anycubic_cloud/camera.py
+++ b/custom_components/anycubic_cloud/camera.py
@@ -19,14 +19,19 @@ whole class. Defining it on the local camera would silently drop the HLS path.
 
 from __future__ import annotations
 
+import secrets
 from dataclasses import dataclass, replace
+from http import HTTPStatus
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit
 
+from aiohttp import ClientError, ClientTimeout, hdrs, web
 from homeassistant.components.camera import (
     Camera,
     CameraEntityDescription,
     CameraEntityFeature,
+    CameraView,
     WebRTCAnswer,
     WebRTCSendMessage,
 )
@@ -36,15 +41,21 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.network import get_url
 from webrtc_models import RTCIceCandidateInit
 
 from .agora import AgoraError, AgoraStreamSession
-from .const import LOGGER, PrinterEntityType
+from .const import CAMERA_STREAM_PORT, LOGGER, PrinterEntityType
 from .entity import AnycubicCloudEntity, AnycubicCloudEntityDescription
 
 # One camera per printer, and starting the stream is a single cloud-free
 # publish, so there is nothing to serialise.
 PARALLEL_UPDATES = 0
+
+_KOBRA_X_MODEL_ID = "20030"
+_LOCAL_STREAM_PROXY_URL = "/api/anycubic_cloud/camera_stream/{entity_id}"
+_STREAM_CHUNK_SIZE = 64 * 1024
+_STREAM_CONNECT_TIMEOUT = 10
 
 if TYPE_CHECKING:
     from .coordinator import AnycubicCloudDataUpdateCoordinator
@@ -141,6 +152,7 @@ class AnycubicCamera(AnycubicCloudEntity, Camera):
         """Initialise both halves -- Camera keeps its own state."""
         super().__init__(*args, **kwargs)
         Camera.__init__(self)
+        self._stream_proxy_token = secrets.token_urlsafe(32)
 
     @property
     def _stream_url(self) -> str | None:
@@ -160,9 +172,34 @@ class AnycubicCamera(AnycubicCloudEntity, Camera):
         if url is None:
             return None
 
+        if self._needs_stream_proxy(url):
+            if self.entity_id is None:
+                return None
+
+            base_url = get_url(
+                self.hass,
+                allow_external=False,
+                prefer_external=False,
+            ).rstrip("/")
+            path = _LOCAL_STREAM_PROXY_URL.format(entity_id=self.entity_id)
+            return f"{base_url}{path}?token={self._stream_proxy_token}"
+
         await self.coordinator.async_start_camera(self._printer_id)
 
         return url
+
+    def _needs_stream_proxy(self, url: str) -> bool:
+        """Return whether this is the Kobra X endpoint that misreports 206."""
+        printer = self.coordinator.get_printer_for_id(self._printer_id)
+
+        if printer is None or str(printer.machine_type) != _KOBRA_X_MODEL_ID:
+            return False
+
+        try:
+            parsed = urlsplit(url)
+            return parsed.scheme == "http" and parsed.port == CAMERA_STREAM_PORT
+        except ValueError:
+            return False
 
     @property
     def use_stream_for_stills(self) -> bool:
@@ -183,6 +220,90 @@ class AnycubicCamera(AnycubicCloudEntity, Camera):
         which only ever proved ffmpeg had been called.
         """
         return True
+
+
+class AnycubicCameraStreamView(CameraView):
+    """Normalize the Kobra X's valid HTTP-FLV response for Home Assistant."""
+
+    url = _LOCAL_STREAM_PROXY_URL
+    name = "api:anycubic_cloud:camera_stream"
+
+    async def get(
+        self,
+        request: web.Request,
+        entity_id: str,
+    ) -> web.StreamResponse:
+        """Authorize the internal consumer with a stable per-entity token."""
+        camera = self.component.get_entity(entity_id)
+
+        if not isinstance(camera, AnycubicCamera):
+            raise web.HTTPNotFound
+
+        token = request.query.get("token", "")
+        if not secrets.compare_digest(token, camera._stream_proxy_token):
+            raise web.HTTPForbidden
+
+        if not camera.is_on:
+            raise web.HTTPServiceUnavailable
+
+        return await self.handle(request, camera)
+
+    async def handle(
+        self,
+        request: web.Request,
+        camera: Camera,
+    ) -> web.StreamResponse:
+        """Relay the stream unchanged, replacing the incorrect 206 with 200."""
+        if not isinstance(camera, AnycubicCamera):
+            raise web.HTTPNotFound
+
+        source_url = camera._stream_url
+
+        if source_url is None:
+            raise web.HTTPServiceUnavailable
+
+        if not camera._needs_stream_proxy(source_url):
+            raise web.HTTPNotFound
+
+        await camera.coordinator.async_start_camera(camera._printer_id)
+
+        try:
+            upstream = await async_get_clientsession(camera.hass).get(
+                source_url,
+                timeout=ClientTimeout(
+                    total=None,
+                    sock_connect=_STREAM_CONNECT_TIMEOUT,
+                    sock_read=None,
+                ),
+            )
+        except (ClientError, TimeoutError) as err:
+            raise web.HTTPBadGateway(reason="Could not connect to the printer camera") from err
+
+        try:
+            if upstream.status not in (HTTPStatus.OK, HTTPStatus.PARTIAL_CONTENT):
+                raise web.HTTPBadGateway(
+                    reason=f"Printer camera returned HTTP {upstream.status}"
+                )
+
+            response = web.StreamResponse(
+                status=HTTPStatus.OK,
+                headers={
+                    hdrs.CONTENT_TYPE: upstream.headers.get(
+                        hdrs.CONTENT_TYPE,
+                        "video/x-flv",
+                    ),
+                    hdrs.CACHE_CONTROL: "no-store",
+                },
+            )
+            await response.prepare(request)
+
+            async for chunk in upstream.content.iter_chunked(_STREAM_CHUNK_SIZE):
+                await response.write(chunk)
+
+            await response.write_eof()
+            return response
+        finally:
+            upstream.release()
 
 
 class AnycubicCloudCamera(AnycubicCloudEntity, Camera):

--- a/tests/test_cloud_camera.py
+++ b/tests/test_cloud_camera.py
@@ -11,9 +11,11 @@ the thing a later refactor is most likely to undo by accident.
 
 from __future__ import annotations
 
+from http import HTTPStatus
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from aiohttp import ClientError, hdrs, web
 from homeassistant.components.camera import Camera, StreamType, WebRTCAnswer
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -22,6 +24,7 @@ from custom_components.anycubic_cloud.agora import AgoraError
 from custom_components.anycubic_cloud.camera import (
     CAMERA_TYPES,
     AnycubicCamera,
+    AnycubicCameraStreamView,
     AnycubicCloudCamera,
 )
 
@@ -56,11 +59,18 @@ def _cloud_camera(hass: HomeAssistant) -> tuple[AnycubicCloudCamera, MagicMock]:
     return camera, coordinator
 
 
-def _local_camera(hass: HomeAssistant, stream_url: str | None = "http://printer/flv") -> tuple[AnycubicCamera, MagicMock]:
+def _local_camera(
+    hass: HomeAssistant,
+    stream_url: str | None = "http://printer/flv",
+    *,
+    machine_type: int = 20025,
+) -> tuple[AnycubicCamera, MagicMock]:
     coordinator = MagicMock()
-    coordinator.printers = {1: MagicMock()}
+    printer = MagicMock(machine_type=machine_type)
+    coordinator.printers = {1: printer}
     coordinator.last_update_success = True
     coordinator.camera_stream_url = MagicMock(return_value=stream_url)
+    coordinator.get_printer_for_id = MagicMock(return_value=printer)
     coordinator.async_start_camera = AsyncMock()
 
     with patch.object(AnycubicCamera, "__init__", lambda self, *a, **k: None):
@@ -70,8 +80,42 @@ def _local_camera(hass: HomeAssistant, stream_url: str | None = "http://printer/
     camera._printer_id = 1
     camera.entity_description = CAMERA_TYPES[0]
     camera.hass = hass
+    camera.entity_id = "camera.anycubic_kobra"
+    camera._stream_proxy_token = "camera-token"
 
     return camera, coordinator
+
+
+def _kobra_x_camera(
+    hass: HomeAssistant,
+    stream_url: str | None = "http://10.0.66.28:18088/flv",
+) -> tuple[AnycubicCamera, MagicMock]:
+    return _local_camera(hass, stream_url, machine_type=20030)
+
+
+def _upstream_response(
+    status: HTTPStatus,
+    *,
+    chunks: tuple[bytes, ...] = (),
+    content_type: str | None = "video/x-flv",
+) -> MagicMock:
+    headers = {} if content_type is None else {hdrs.CONTENT_TYPE: content_type}
+    response = MagicMock(status=status, headers=headers)
+
+    async def body():
+        for chunk in chunks:
+            yield chunk
+
+    response.content.iter_chunked.return_value = body()
+    return response
+
+
+def _downstream_response() -> MagicMock:
+    response = MagicMock()
+    response.prepare = AsyncMock()
+    response.write = AsyncMock()
+    response.write_eof = AsyncMock()
+    return response
 
 
 class TestTheTwoTransportsStaySeparate:
@@ -322,3 +366,186 @@ class TestStillsComeOffTheStreamHomeAssistantAlreadyHas:
 
         assert await camera.stream_source() is None
         coordinator.async_start_camera.assert_not_awaited()
+
+
+class TestKobraXPartialContentStream:
+    """The Kobra X sends valid FLV with HTTP 206 even without a Range request."""
+
+    async def test_only_the_affected_model_uses_the_proxy(self, hass: HomeAssistant) -> None:
+        camera, coordinator = _kobra_x_camera(hass)
+
+        with patch(
+            "custom_components.anycubic_cloud.camera.get_url",
+            return_value="http://homeassistant.local:8123",
+        ):
+            source = await camera.stream_source()
+
+        assert source == (
+            "http://homeassistant.local:8123/api/anycubic_cloud/camera_stream/camera.anycubic_kobra?token=camera-token"
+        )
+        coordinator.async_start_camera.assert_not_awaited()
+
+    async def test_the_proxy_requires_its_entity_token(self, hass: HomeAssistant) -> None:
+        camera, _ = _kobra_x_camera(hass)
+        component = MagicMock()
+        component.get_entity.return_value = camera
+        view = AnycubicCameraStreamView(component)
+        request = MagicMock()
+        request.query = {"token": "wrong"}
+
+        with pytest.raises(web.HTTPForbidden):
+            await view.get(request, camera.entity_id)
+
+    async def test_the_proxy_accepts_its_entity_token(self, hass: HomeAssistant) -> None:
+        camera, _ = _kobra_x_camera(hass)
+        component = MagicMock()
+        component.get_entity.return_value = camera
+        view = AnycubicCameraStreamView(component)
+        view.handle = AsyncMock(return_value=MagicMock())
+        request = MagicMock()
+        request.query = {"token": "camera-token"}
+
+        await view.get(request, camera.entity_id)
+
+        view.handle.assert_awaited_once_with(request, camera)
+
+    async def test_other_endpoints_keep_the_direct_path(self, hass: HomeAssistant) -> None:
+        camera, coordinator = _kobra_x_camera(hass, "http://10.0.66.28:8080/flv")
+
+        assert await camera.stream_source() == "http://10.0.66.28:8080/flv"
+        coordinator.async_start_camera.assert_awaited_once_with(1)
+
+    async def test_malformed_urls_keep_the_direct_path(self, hass: HomeAssistant) -> None:
+        camera, coordinator = _kobra_x_camera(hass, "http://printer:not-a-port/flv")
+
+        assert await camera.stream_source() == "http://printer:not-a-port/flv"
+        coordinator.async_start_camera.assert_awaited_once_with(1)
+
+    async def test_the_proxy_normalizes_206_without_touching_the_body(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        camera, coordinator = _kobra_x_camera(hass)
+        upstream = _upstream_response(
+            HTTPStatus.PARTIAL_CONTENT,
+            chunks=(b"FLV", b"video-bytes"),
+        )
+        session = MagicMock()
+        session.get = AsyncMock(return_value=upstream)
+        downstream = _downstream_response()
+
+        with (
+            patch(
+                "custom_components.anycubic_cloud.camera.async_get_clientsession",
+                return_value=session,
+            ),
+            patch(
+                "custom_components.anycubic_cloud.camera.web.StreamResponse",
+                return_value=downstream,
+            ) as stream_response,
+        ):
+            response = await AnycubicCameraStreamView(MagicMock()).handle(
+                MagicMock(),
+                camera,
+            )
+
+        assert response is downstream
+        coordinator.async_start_camera.assert_awaited_once_with(1)
+        session.get.assert_awaited_once()
+        timeout = session.get.await_args.kwargs["timeout"]
+        assert timeout.total is None
+        assert timeout.sock_connect == 10
+        stream_response.assert_called_once_with(
+            status=HTTPStatus.OK,
+            headers={
+                hdrs.CONTENT_TYPE: "video/x-flv",
+                hdrs.CACHE_CONTROL: "no-store",
+            },
+        )
+        assert [call.args[0] for call in downstream.write.await_args_list] == [
+            b"FLV",
+            b"video-bytes",
+        ]
+        downstream.write_eof.assert_awaited_once()
+        upstream.release.assert_called_once()
+
+    async def test_a_fixed_firmware_returning_200_is_also_accepted(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        camera, _ = _kobra_x_camera(hass)
+        upstream = _upstream_response(HTTPStatus.OK, content_type=None)
+        session = MagicMock()
+        session.get = AsyncMock(return_value=upstream)
+        downstream = _downstream_response()
+
+        with (
+            patch(
+                "custom_components.anycubic_cloud.camera.async_get_clientsession",
+                return_value=session,
+            ),
+            patch(
+                "custom_components.anycubic_cloud.camera.web.StreamResponse",
+                return_value=downstream,
+            ) as stream_response,
+        ):
+            await AnycubicCameraStreamView(MagicMock()).handle(MagicMock(), camera)
+
+        assert stream_response.call_args.kwargs["headers"][hdrs.CONTENT_TYPE] == "video/x-flv"
+        upstream.release.assert_called_once()
+
+    async def test_upstream_http_errors_become_bad_gateway(self, hass: HomeAssistant) -> None:
+        camera, _ = _kobra_x_camera(hass)
+        upstream = _upstream_response(HTTPStatus.NOT_FOUND)
+        session = MagicMock()
+        session.get = AsyncMock(return_value=upstream)
+
+        with (
+            patch(
+                "custom_components.anycubic_cloud.camera.async_get_clientsession",
+                return_value=session,
+            ),
+            pytest.raises(web.HTTPBadGateway, match="HTTP 404"),
+        ):
+            await AnycubicCameraStreamView(MagicMock()).handle(MagicMock(), camera)
+
+        upstream.release.assert_called_once()
+
+    async def test_connection_errors_become_bad_gateway(self, hass: HomeAssistant) -> None:
+        camera, _ = _kobra_x_camera(hass)
+        session = MagicMock()
+        session.get = AsyncMock(side_effect=ClientError("offline"))
+
+        with (
+            patch(
+                "custom_components.anycubic_cloud.camera.async_get_clientsession",
+                return_value=session,
+            ),
+            pytest.raises(web.HTTPBadGateway, match="Could not connect"),
+        ):
+            await AnycubicCameraStreamView(MagicMock()).handle(MagicMock(), camera)
+
+    @pytest.mark.parametrize("stream_url", [None, "http://printer:18088/flv"])
+    async def test_the_proxy_rejects_unavailable_or_unaffected_cameras(
+        self,
+        hass: HomeAssistant,
+        stream_url: str | None,
+    ) -> None:
+        camera, coordinator = _local_camera(
+            hass,
+            stream_url,
+            machine_type=20025,
+        )
+        expected = web.HTTPServiceUnavailable if stream_url is None else web.HTTPNotFound
+
+        with pytest.raises(expected):
+            await AnycubicCameraStreamView(MagicMock()).handle(MagicMock(), camera)
+
+        coordinator.async_start_camera.assert_not_awaited()
+
+    async def test_the_proxy_rejects_other_camera_integrations(self) -> None:
+        with pytest.raises(web.HTTPNotFound):
+            await AnycubicCameraStreamView(MagicMock()).handle(
+                MagicMock(),
+                MagicMock(spec=Camera),
+            )

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from helpers import PRINTER_ID
 from helpers import setup_entry as _setup
+from homeassistant.components.camera.const import DATA_COMPONENT as DATA_CAMERA_COMPONENT
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 
@@ -59,6 +60,8 @@ class TestRegistration:
     async def test_all_actions_are_registered_before_setup(self, hass: HomeAssistant) -> None:
         from custom_components.anycubic_cloud import async_setup
 
+        hass.data[DATA_CAMERA_COMPONENT] = MagicMock()
+        hass.http = MagicMock()
         await async_setup(hass, {})
 
         missing = [n for n in SERVICE_NAMES if not hass.services.has_service(DOMAIN, n)]


### PR DESCRIPTION
## Problem

The Kobra X LAN camera serves a valid HTTP-FLV/H.264 stream, but responds to a normal GET with `206 Partial Content` even though the request has no `Range` header. Home Assistant's go2rtc HTTP producer rejects that status before it reads the FLV payload, so both the live view and stream-backed snapshots fail with `206 Partial Content`; the later RTSP `DESCRIBE 404` is only the fallback failing after the original source was rejected.

This is the remaining hardware-specific cause behind #20 after the snapshot path was changed to reuse Home Assistant's existing stream.

## Solution

- Route only Kobra X (`machine_type=20030`) LAN camera URLs on the known HTTP-FLV port (`18088`) through a small Home Assistant view.
- Start capture when that internal view is actually requested.
- Accept `200 OK` or the Kobra X's incorrect `206 Partial Content`, then return `200 OK` downstream while forwarding the content type and FLV bytes unchanged.
- Protect the internal URL with a stable random token scoped to the camera entity, so go2rtc reconnects remain authorized without exposing an unauthenticated endpoint.
- Leave every other printer model and camera URL on the existing direct path.

There is no transcoding, additional ffmpeg process, dashboard change, generic fallback, or change to the cloud camera transport.

## Validation

Hardware validation on a Kobra X in LAN mode confirmed:

- the printer returns `206` with a valid 1280x720 H.264 FLV stream;
- the normalized stream opens in Home Assistant and produces a valid 1280x720 JPEG snapshot;
- the relay forwards the original stream rather than transcoding it.

Repository checks:

- `ruff check custom_components tests`
- `ruff format --check tests`
- `mypy custom_components/anycubic_cloud`
- `pytest tests -q --cov=custom_components.anycubic_cloud --cov-report=term-missing --cov-fail-under=95` (96.36% coverage)
- frontend entity resolver: 33/33 cases passed

Fixes #20
